### PR TITLE
Add configurable raft log path and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ If you decide to modify the code yourself, you can run
 to append dependency information to the Makefile, so that make
 knows which files depend on each other and recompiles all the
 necessary files on changes.
+
+## Raft replication log
+
+The server records NFS operations to a log that can be replayed on
+other replicas for consistency. By default this log is written to
+`raft.log`. Use the `-R <file>` option to select a different path.


### PR DESCRIPTION
## Summary
- add `-R` option to configure Raft log location
- document the Raft log feature in `README.md`
- clarify handle refresh logic and logging in `daemon.c`
- revert previous modification to `nfs.c`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6841afbaf7708333b682937b8da0d321