### PR TITLE
Enhance handle log to track rename and delete

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -965,12 +965,26 @@ static void nfs3_program_3(struct svc_req *rqstp, register SVCXPRT * transp)
             char *path = fh_decomp(argument.nfsproc3_remove_3_arg.object.dir);
             raft_log("REMOVE %s/%s", path ? path : "?",
                      argument.nfsproc3_remove_3_arg.object.name);
+            REMOVE3res *res = (REMOVE3res *)result;
+            if (res && res->status == NFS3_OK && path) {
+                char full[NFS_MAXPATHLEN];
+                snprintf(full, sizeof(full), "%s/%s", path,
+                         argument.nfsproc3_remove_3_arg.object.name);
+                handle_log_record_remove(remote_host, full);
+            }
             break;
         }
         case NFSPROC3_RMDIR: {
             char *path = fh_decomp(argument.nfsproc3_rmdir_3_arg.object.dir);
             raft_log("RMDIR %s/%s", path ? path : "?",
                      argument.nfsproc3_rmdir_3_arg.object.name);
+            RMDIR3res *res = (RMDIR3res *)result;
+            if (res && res->status == NFS3_OK && path) {
+                char full[NFS_MAXPATHLEN];
+                snprintf(full, sizeof(full), "%s/%s", path,
+                         argument.nfsproc3_rmdir_3_arg.object.name);
+                handle_log_record_remove(remote_host, full);
+            }
             break;
         }
         case NFSPROC3_RENAME: {
@@ -980,6 +994,16 @@ static void nfs3_program_3(struct svc_req *rqstp, register SVCXPRT * transp)
                      argument.nfsproc3_rename_3_arg.from.name,
                      to ? to : "?",
                      argument.nfsproc3_rename_3_arg.to.name);
+            RENAME3res *res = (RENAME3res *)result;
+            if (res && res->status == NFS3_OK && from && to) {
+                char old[NFS_MAXPATHLEN];
+                char newp[NFS_MAXPATHLEN];
+                snprintf(old, sizeof(old), "%s/%s", from,
+                         argument.nfsproc3_rename_3_arg.from.name);
+                snprintf(newp, sizeof(newp), "%s/%s", to,
+                         argument.nfsproc3_rename_3_arg.to.name);
+                handle_log_record_rename(remote_host, old, newp);
+            }
             break;
         }
         case NFSPROC3_LINK: {

--- a/handle_log.c
+++ b/handle_log.c
@@ -11,13 +11,16 @@
 #endif
 
 struct handle_entry {
+    enum handle_log_op op;
     char client[INET6_ADDRSTRLEN];
     char path[NFS_MAXPATHLEN];
+    char path2[NFS_MAXPATHLEN];
     char handle_hex[FH_MAXBUF * 2 + 1];
     struct handle_entry *next;
 };
 
 static struct handle_entry *entries = NULL;
+static struct handle_entry *entries_tail = NULL;
 static FILE *handle_fp = NULL;
 
 static void fh_to_hex(const nfs_fh3 *fh, char *out)
@@ -36,26 +39,54 @@ void handle_log_init(const char *path)
     if (!handle_fp)
         return;
 
-    char line[INET6_ADDRSTRLEN + NFS_MAXPATHLEN + FH_MAXBUF * 2 + 8];
+    char line[INET6_ADDRSTRLEN + NFS_MAXPATHLEN * 2 + FH_MAXBUF * 2 + 16];
     rewind(handle_fp);
     while (fgets(line, sizeof(line), handle_fp)) {
         char *saveptr = NULL;
-        char *client = strtok_r(line, " \t\n", &saveptr);
-        char *p = strtok_r(NULL, " \t\n", &saveptr);
-        char *hex = strtok_r(NULL, " \t\n", &saveptr);
-        if (!client || !p || !hex)
+        char *op = strtok_r(line, " \t\n", &saveptr);
+        char *client = strtok_r(NULL, " \t\n", &saveptr);
+        if (!op || !client)
             continue;
-        struct handle_entry *e = malloc(sizeof(*e));
+        struct handle_entry *e = calloc(1, sizeof(*e));
         if (!e)
             break;
+        if (strcmp(op, "H") == 0) {
+            e->op = HANDLE_LOG_ADD;
+            char *p = strtok_r(NULL, " \t\n", &saveptr);
+            char *hex = strtok_r(NULL, " \t\n", &saveptr);
+            if (!p || !hex) { free(e); continue; }
+            strncpy(e->path, p, NFS_MAXPATHLEN);
+            e->path[NFS_MAXPATHLEN - 1] = '\0';
+            strncpy(e->handle_hex, hex, FH_MAXBUF * 2);
+            e->handle_hex[FH_MAXBUF * 2] = '\0';
+        } else if (strcmp(op, "R") == 0) {
+            e->op = HANDLE_LOG_RENAME;
+            char *from = strtok_r(NULL, " \t\n", &saveptr);
+            char *to = strtok_r(NULL, " \t\n", &saveptr);
+            if (!from || !to) { free(e); continue; }
+            strncpy(e->path, from, NFS_MAXPATHLEN);
+            e->path[NFS_MAXPATHLEN - 1] = '\0';
+            strncpy(e->path2, to, NFS_MAXPATHLEN);
+            e->path2[NFS_MAXPATHLEN - 1] = '\0';
+        } else if (strcmp(op, "D") == 0) {
+            e->op = HANDLE_LOG_REMOVE;
+            char *p = strtok_r(NULL, " \t\n", &saveptr);
+            if (!p) { free(e); continue; }
+            strncpy(e->path, p, NFS_MAXPATHLEN);
+            e->path[NFS_MAXPATHLEN - 1] = '\0';
+        } else {
+            free(e);
+            continue;
+        }
         strncpy(e->client, client, INET6_ADDRSTRLEN);
         e->client[INET6_ADDRSTRLEN - 1] = '\0';
-        strncpy(e->path, p, NFS_MAXPATHLEN);
-        e->path[NFS_MAXPATHLEN - 1] = '\0';
-        strncpy(e->handle_hex, hex, FH_MAXBUF * 2);
-        e->handle_hex[FH_MAXBUF * 2] = '\0';
-        e->next = entries;
-        entries = e;
+        e->next = NULL;
+        if (!entries) {
+            entries = entries_tail = e;
+        } else {
+            entries_tail->next = e;
+            entries_tail = e;
+        }
     }
     fseek(handle_fp, 0, SEEK_END);
 }
@@ -70,27 +101,91 @@ void handle_log_close(void)
         free(entries);
         entries = n;
     }
+    entries_tail = NULL;
 }
 
 void handle_log_record(const char *client, const char *path, const nfs_fh3 *fh)
 {
     if (!handle_fp)
         return;
-    struct handle_entry *e = malloc(sizeof(*e));
+    struct handle_entry *e = calloc(1, sizeof(*e));
     if (!e)
         return;
+    e->op = HANDLE_LOG_ADD;
     strncpy(e->client, client, INET6_ADDRSTRLEN);
     e->client[INET6_ADDRSTRLEN - 1] = '\0';
     strncpy(e->path, path, NFS_MAXPATHLEN);
     e->path[NFS_MAXPATHLEN - 1] = '\0';
     fh_to_hex(fh, e->handle_hex);
-    e->next = entries;
-    entries = e;
+    e->next = NULL;
+    if (!entries) {
+        entries = entries_tail = e;
+    } else {
+        entries_tail->next = e;
+        entries_tail = e;
+    }
 
     logmsg(LOG_INFO, "handle_log_record: client=%s path=%s fh=%s", client, path,
            e->handle_hex);
 
-    fprintf(handle_fp, "%s %s %s\n", e->client, e->path, e->handle_hex);
+    fprintf(handle_fp, "H %s %s %s\n", e->client, e->path, e->handle_hex);
+    fflush(handle_fp);
+}
+
+void handle_log_record_rename(const char *client, const char *oldpath,
+                              const char *newpath)
+{
+    if (!handle_fp)
+        return;
+    struct handle_entry *e = calloc(1, sizeof(*e));
+    if (!e)
+        return;
+    e->op = HANDLE_LOG_RENAME;
+    strncpy(e->client, client, INET6_ADDRSTRLEN);
+    e->client[INET6_ADDRSTRLEN - 1] = '\0';
+    strncpy(e->path, oldpath, NFS_MAXPATHLEN);
+    e->path[NFS_MAXPATHLEN - 1] = '\0';
+    strncpy(e->path2, newpath, NFS_MAXPATHLEN);
+    e->path2[NFS_MAXPATHLEN - 1] = '\0';
+    e->next = NULL;
+    if (!entries) {
+        entries = entries_tail = e;
+    } else {
+        entries_tail->next = e;
+        entries_tail = e;
+    }
+
+    logmsg(LOG_INFO, "handle_log_record_rename: client=%s %s -> %s", client,
+           oldpath, newpath);
+
+    fprintf(handle_fp, "R %s %s %s\n", e->client, e->path, e->path2);
+    fflush(handle_fp);
+}
+
+void handle_log_record_remove(const char *client, const char *path)
+{
+    if (!handle_fp)
+        return;
+    struct handle_entry *e = calloc(1, sizeof(*e));
+    if (!e)
+        return;
+    e->op = HANDLE_LOG_REMOVE;
+    strncpy(e->client, client, INET6_ADDRSTRLEN);
+    e->client[INET6_ADDRSTRLEN - 1] = '\0';
+    strncpy(e->path, path, NFS_MAXPATHLEN);
+    e->path[NFS_MAXPATHLEN - 1] = '\0';
+    e->next = NULL;
+    if (!entries) {
+        entries = entries_tail = e;
+    } else {
+        entries_tail->next = e;
+        entries_tail = e;
+    }
+
+    logmsg(LOG_INFO, "handle_log_record_remove: client=%s path=%s", client,
+           path);
+
+    fprintf(handle_fp, "D %s %s\n", e->client, e->path);
     fflush(handle_fp);
 }
 
@@ -98,13 +193,33 @@ const char *handle_log_lookup(const char *client, const nfs_fh3 *fh)
 {
     char hex[FH_MAXBUF * 2 + 1];
     fh_to_hex(fh, hex);
+
     struct handle_entry *e;
-    for (e = entries; e; e = e->next)
-        if (strcmp(e->client, client) == 0 && strcmp(e->handle_hex, hex) == 0)
-            {
-                logmsg(LOG_INFO, "handle_log_lookup: found path %s for client=%s fh=%s", e->path, client, hex);
-                return e->path;
+    const char *path = NULL;
+
+    for (e = entries; e; e = e->next) {
+        if (!path) {
+            if (e->op == HANDLE_LOG_ADD &&
+                strcmp(e->client, client) == 0 &&
+                strcmp(e->handle_hex, hex) == 0) {
+                path = e->path;
             }
-    logmsg(LOG_INFO, "handle_log_lookup: no entry for client=%s fh=%s", client, hex);
-    return NULL;
+        } else {
+            if (strcmp(e->client, client) != 0)
+                continue;
+            if (e->op == HANDLE_LOG_RENAME && strcmp(e->path, path) == 0) {
+                path = e->path2;
+            } else if (e->op == HANDLE_LOG_REMOVE && strcmp(e->path, path) == 0) {
+                path = NULL;
+            }
+        }
+    }
+
+    if (path)
+        logmsg(LOG_INFO, "handle_log_lookup: found path %s for client=%s fh=%s",
+               path, client, hex);
+    else
+        logmsg(LOG_INFO, "handle_log_lookup: no entry for client=%s fh=%s",
+               client, hex);
+    return path;
 }

--- a/handle_log.h
+++ b/handle_log.h
@@ -4,9 +4,19 @@
 #include <rpc/rpc.h>
 #include "nfs.h"
 
+enum handle_log_op {
+    HANDLE_LOG_ADD,
+    HANDLE_LOG_RENAME,
+    HANDLE_LOG_REMOVE
+};
+
 void handle_log_init(const char *path);
 void handle_log_close(void);
-void handle_log_record(const char *client, const char *path, const nfs_fh3 *fh);
+void handle_log_record(const char *client, const char *path,
+                       const nfs_fh3 *fh);
+void handle_log_record_rename(const char *client, const char *oldpath,
+                              const char *newpath);
+void handle_log_record_remove(const char *client, const char *path);
 const char *handle_log_lookup(const char *client, const nfs_fh3 *fh);
 
 #endif /* HANDLE_LOG_H */


### PR DESCRIPTION
## Summary
- extend handle log API to capture rename and remove operations
- keep log entries in chronological order
- update handle lookup to apply rename/remove entries
- log rename and deletion results in daemon

## Testing
- `make unfsd`


------
https://chatgpt.com/codex/tasks/task_e_684af1797710833391c7af2cb819aad5